### PR TITLE
Allow empty data in fractal builder to pass to resource classes

### DIFF
--- a/src/FractalBuilder.php
+++ b/src/FractalBuilder.php
@@ -257,10 +257,6 @@ class FractalBuilder implements FractalBuilderContract
      */
     private function setData($data)
     {
-        if (empty($data)) {
-            throw new InvalidArgument('Data must not be empty.');
-        }
-
         $this->data = $data;
     }
 }


### PR DESCRIPTION
Fixes #3

Changes proposed in this pull request:
- Allow empty data in resource classes. Without this, you cannot pass an empty array, for example, to the builder. Fractal docs say "The Item and Collection constructors will take any kind of data you wish to send it as the first argument, and then a “transformer” as the second argument.".
